### PR TITLE
Update available-regions-intro.md

### DIFF
--- a/doc_source/available-regions-intro.md
+++ b/doc_source/available-regions-intro.md
@@ -9,6 +9,7 @@ AWS Storage Gateway stores volume, snapshot, tape, and file data in the AWS Regi
 | US East \(N\. Virginia\) | us\-east\-1 | yes | yes | yes | 
 | US West \(N\. California\) | us\-west\-1 | yes | yes | yes | 
 | US West \(Oregon\) | us\-west\-2 | yes | yes | yes | 
+| US GovCloud \(West\) | us-gov-west-1 | yes | yes | yes | 
 | Canada \(Central\) | ca\-central\-1 | yes | yes | yes | 
 | EU \(Ireland\) | eu\-west\-1 | yes | yes | yes | 
 | EU \(Frankfurt\) | eu\-central\-1 | yes | yes | yes | 


### PR DESCRIPTION
Updating this file to note that AWS Storage Gateway is now GA in us-gov-west-1 per https://aws.amazon.com/about-aws/whats-new/2018/03/storage-gateway-govcloud/

*Issue #, if available:* None

*Description of changes:*
Added row for us-gov-west-1 per the above press release and AWS GovCloud documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
