### PR TITLE
Update get-activation-key.md

### DIFF
--- a/doc_source/get-activation-key.md
+++ b/doc_source/get-activation-key.md
@@ -66,3 +66,7 @@ function Get-ActivationKey {
   }
 }
 ```
+
+> If activating from inside a secure (non internet enabled) VPC then you will need to add an extra parameter and argument to the URL.
+> 
+> ``` &vpcEndpoint=$theVPCEndpoint ```


### PR DESCRIPTION
I have spent the last week trying to identify why my storage gateway would not activate inside my Secured VPC which is part of a LandingZone deployment. I have eventually identified that this is related to the requirement to include the private VPCEndpoint in the URL. 
This is not clearly documented anywhere and so I suggest it is added here.

*Issue #, if available:* 
No issue raised

*Description of changes:* 
Added a section at the bottom to highlight the requirement to include the VPCEndpoint argument to the URL when activaiting inside a Secure VPC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
